### PR TITLE
Persistence and API routes for games & moves

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .vscode
 node_modules
 coverage
+
+*.sqlite

--- a/lib/Board.js
+++ b/lib/Board.js
@@ -53,6 +53,17 @@ class Board {
 	}
 
 	/**
+	 * Returns whether a given token belongs to a given player
+	 * @param {{x: Number, y: Number}} coordinates coordinates of the token
+	 * @param {Number|String} playerId the id of the player
+	 * @returns {Boolean} `true` if the token belongs to the player, otherwise `false`
+	 */
+	tokenBelongsToPlayer({ x, y }, playerId) {
+		const playerTokens = this.tokens[playerId.toString()] || [];
+		return playerTokens.some((token) => token.x === x && token.y === y);
+	}
+
+	/**
 	 * Returns all neighbours of a disc
 	 * @param {{x: Number, y: Number}} coordinates coordinates of the disc
 	 * @returns {Array<Disc>} list of discs

--- a/lib/Board.js
+++ b/lib/Board.js
@@ -141,6 +141,7 @@ class Board {
 	canMoveTokenTo(coordinates, target) {
 		return this.getToken(coordinates) && allDirections
 			.map((direction) => this.getMaximumTokenMovementInDirection(coordinates, direction))
+			.filter((tile) => tile.x !== coordinates.x || tile.y !== coordinates.y)
 			.some((tile) => tile.x === target.x && tile.y === target.y);
 	}
 

--- a/lib/Board.js
+++ b/lib/Board.js
@@ -255,6 +255,19 @@ class Board {
 	}
 
 	/**
+	 * Returns `true` if the given disc can be moved to the given target, which
+	 * entails both the disc being moveable and the target being a valid move target.
+	 * Returns `false` otherwise
+	 * @param {{x: Number, y: Number}} coordinates coordinates of the disc to move
+	 * @param {{x: Number, y: Number}} target target coordinates
+	 * @returns {boolean} `true` if the move is possible, `false` otherwise
+	 */
+	canMoveDiscTo(coordinates, target) {
+		return this.canMoveDisc(coordinates)
+			&& this.getDiscMoveTargets(coordinates).some((t) => t.x === target.x && t.y === target.y);
+	}
+
+	/**
 	 * Moves a disc to new coordinates and updates indexes accordingly
 	 * @param {{x: Number, y: Number}} coordinates coordinates of the disc to move
 	 * @param {{x: Number, y: Number}} target target coordinates

--- a/lib/Board.test.js
+++ b/lib/Board.test.js
@@ -132,6 +132,16 @@ describe('Board', () => {
 			expect(cornerBoard.canMoveTokenTo({ x: 0, y: -1 }, { x: 1, y: 2 })).toEqual(false);
 		});
 
+		it('should give false if (from === to)', () => {
+			const cornerBoard = new Board([
+				{ id: 0, x: 0, y: -1 },
+				{ id: 1, x: 0, y: 0 },
+				{ id: 2, x: 1, y: 1 },
+				{ id: 3, x: 1, y: 2 },
+			], { 0: [{ x: 0, y: -1 }] });
+			expect(cornerBoard.canMoveTokenTo({ x: 0, y: -1 }, { x: 0, y: -1 })).toEqual(false);
+		});
+
 		it('should give false if movement is blocked by own tokens', () => {
 			const lineBoard = new Board([
 				{ id: 0, x: 0, y: 0 },

--- a/lib/Board.test.js
+++ b/lib/Board.test.js
@@ -35,6 +35,24 @@ describe('Board', () => {
 		expect(getCustomBoard().tokens[2]).toStrictEqual([]);
 	});
 
+	describe('#tokenBelongsToPlayer', () => {
+		it('gives true if the token belongs to the given player', () => {
+			expect(theBoard.tokenBelongsToPlayer({ x: -2, y: 0 }, 0)).toBe(true);
+			expect(theBoard.tokenBelongsToPlayer({ x: 2, y: 2 }, 0)).toBe(true);
+			expect(theBoard.tokenBelongsToPlayer({ x: 0, y: -2 }, 0)).toBe(true);
+
+			expect(theBoard.tokenBelongsToPlayer({ x: 0, y: 2 }, 1)).toBe(true);
+			expect(theBoard.tokenBelongsToPlayer({ x: 2, y: 0 }, 1)).toBe(true);
+			expect(theBoard.tokenBelongsToPlayer({ x: -2, y: -2 }, 1)).toBe(true);
+		});
+
+		it('gives false if the token does not belong to the given player', () => {
+			expect(theBoard.tokenBelongsToPlayer({ x: -2, y: 0 }, 1)).toBe(false); // different player
+			expect(theBoard.tokenBelongsToPlayer({ x: 0, y: -2 }, 2)).toBe(false); // non-existant player
+			expect(theBoard.tokenBelongsToPlayer({ x: 0, y: 0 }, 1)).toBe(false); // non-existant token
+		});
+	});
+
 	describe('#getNeighbours', () => {
 		it('works', () => {
 			const neighbours = theBoard.getNeighbours({ x: 0, y: -1 });

--- a/lib/Board.test.js
+++ b/lib/Board.test.js
@@ -407,6 +407,25 @@ describe('Board', () => {
 		});
 	});
 
+	describe('#canMoveDiscTo', () => {
+		it('returns true for valid moves', () => {
+			expect(theBoard.canMoveDiscTo({ x: -2, y: -1 }, { x: -2, y: 1 })).toBe(true);
+			expect(theBoard.canMoveDiscTo({ x: 1, y: 2 }, { x: 0, y: 3 })).toBe(true);
+			expect(theBoard.canMoveDiscTo({ x: 1, y: -1 }, { x: -3, y: -3 })).toBe(true);
+		});
+
+		it('returns false for unmoveable discs', () => {
+			expect(theBoard.canMoveDiscTo({ x: -2, y: -2 }, { x: -2, y: 1 })).toBe(false);
+			expect(theBoard.canMoveDiscTo({ x: -1, y: -1 }, { x: 0, y: 3 })).toBe(false);
+		});
+
+		it('returns false if the target is invalid', () => {
+			expect(theBoard.canMoveDiscTo({ x: -2, y: -1 }, { x: -5, y: 1 })).toBe(false);
+			expect(theBoard.canMoveDiscTo({ x: 1, y: 2 }, { x: 0, y: 2 })).toBe(false);
+			expect(theBoard.canMoveDiscTo({ x: 1, y: -1 }, { x: 0, y: 0 })).toBe(false);
+		});
+	});
+
 	describe('#moveDisc', () => {
 		it('should remove the disc at the original location', () => {
 			const lineBoard = new Board([

--- a/lib/BoardFactory.js
+++ b/lib/BoardFactory.js
@@ -1,3 +1,5 @@
+const { Board } = require('./Board');
+
 class BoardFactory {
 	/**
 	 * Returns JSON-compatible object representation of a board
@@ -20,6 +22,20 @@ class BoardFactory {
 				neighbours: board.getNeighbours(disc),
 			})),
 		};
+	}
+
+	/**
+	 * Returns a Board instance based on the given object representation
+	 * @param {Object} object plain object representation of a board
+	 * @returns {Board} the board
+	 */
+	static createBoardFromObject(object) {
+		const tiles = object.discs.map((d) => ({ id: d.id, x: d.x, y: d.y }));
+		const tokens = {};
+		object.players.forEach((player) => {
+			tokens[player.id] = player.tokens.map((t) => t.tile);
+		});
+		return new Board(tiles, tokens);
 	}
 }
 

--- a/lib/BoardFactory.test.js
+++ b/lib/BoardFactory.test.js
@@ -1,0 +1,57 @@
+const { BoardFactory } = require('./BoardFactory');
+const { Board } = require('./Board');
+
+const mapToSet = (arr) => new Set(arr.map((t) => `${t.x}:${t.y}`));
+
+describe('BoardFactory', () => {
+	describe('round trip', () => {
+		it('does not throw', () => {
+			expect(() => BoardFactory.createBoardFromObject(BoardFactory.toObject(new Board()))).not.toThrow();
+		});
+
+		const expectEqualBoards = (a, b) => {
+			expect(new Set(Object.keys(b.tokens)))
+				.toStrictEqual(new Set(Object.keys(a.tokens)));
+
+			Object.keys(b.tokens).forEach((key) => {
+				const tokenset = mapToSet(b.tokens[key]);
+				const defaultTokenset = mapToSet(a.tokens[key]);
+				expect(tokenset).toStrictEqual(defaultTokenset);
+			});
+
+			const discTargets = mapToSet(b.getDiscMoveTargets({ x: 0, y: 0 }));
+			const defaultTargets = mapToSet(a.getDiscMoveTargets({ x: 0, y: 0 }));
+			expect(discTargets).toStrictEqual(defaultTargets);
+		};
+
+		it('works for default board', () => {
+			const defaultBoard = new Board();
+			const object = BoardFactory.toObject(defaultBoard);
+			const loadedBoard = BoardFactory.createBoardFromObject(object);
+
+			expect(loadedBoard).not.toBeUndefined();
+			expect(loadedBoard).not.toBe(defaultBoard);
+			expectEqualBoards(defaultBoard, loadedBoard);
+		});
+
+		it('works for custom board', () => {
+			const lineBoard = new Board([
+				{ id: 0, x: 0, y: 0 },
+				{ id: 1, x: 1, y: 0 },
+				{ id: 2, x: 2, y: 0 },
+				{ id: 3, x: 3, y: 0 },
+			], {
+				0: [
+					{ x: 0, y: 0 },
+				],
+				1: [
+					{ x: 1, y: 0 },
+				],
+				2: [
+					{ x: 2, y: 0 },
+				],
+			});
+			expectEqualBoards(lineBoard, BoardFactory.createBoardFromObject(BoardFactory.toObject(lineBoard)));
+		});
+	});
+});

--- a/lib/Errors.js
+++ b/lib/Errors.js
@@ -1,5 +1,21 @@
-class InvalidInputError extends Error {}
+class ApplicationError extends Error { status() { return 500; }}
+
+class InvalidInputError extends ApplicationError {
+	constructor(message = 'You supplied an invalid input.') { super(message); }
+
+	status() { return 400; }
+}
+class InvalidMoveError extends InvalidInputError {
+	constructor(message = 'The given move is invalid.') { super(message); }
+}
+
+class IllegalMoveError extends InvalidInputError {
+	constructor(message = 'The given move is not possible.') { super(message); }
+}
 
 module.exports = {
+	ApplicationError,
 	InvalidInputError,
+	InvalidMoveError,
+	IllegalMoveError,
 };

--- a/lib/Game.js
+++ b/lib/Game.js
@@ -1,5 +1,7 @@
 const db = require('quick.db');
 const { nanoid } = require('nanoid');
+const { Board } = require('./Board');
+const { BoardFactory } = require('./BoardFactory');
 
 // eslint-disable-next-line new-cap
 const games = new db.table('games');
@@ -9,6 +11,11 @@ class Game {
 		this.pid = pid;
 		this.players = players;
 		this.gamestate = gamestate;
+		if (!gamestate.board) {
+			this.gamestate.board = new Board();
+		} else {
+			this.gamestate.board = BoardFactory.createBoardFromObject(gamestate.board);
+		}
 	}
 
 	static getByPid(pid) {
@@ -24,7 +31,10 @@ class Game {
 		return {
 			pid: this.pid,
 			players: this.players,
-			gamestate: this.gamestate,
+			gamestate: {
+				...this.gamestate,
+				board: BoardFactory.toObject(this.gamestate.board),
+			},
 		};
 	}
 

--- a/lib/Game.js
+++ b/lib/Game.js
@@ -18,6 +18,12 @@ class Game {
 		}
 	}
 
+	static createNew(data) {
+		const game = new Game(data);
+		game.save();
+		return game;
+	}
+
 	static getByPid(pid) {
 		const game = games.get(pid);
 		return new Game(game);

--- a/lib/Game.js
+++ b/lib/Game.js
@@ -1,0 +1,39 @@
+const db = require('quick.db');
+const { nanoid } = require('nanoid');
+
+// eslint-disable-next-line new-cap
+const games = new db.table('games');
+
+class Game {
+	constructor({ pid = nanoid(), players = 2, gamestate = {} }) {
+		this.pid = pid;
+		this.players = players;
+		this.gamestate = gamestate;
+	}
+
+	static getByPid(pid) {
+		const game = games.get(pid);
+		return new Game(game);
+	}
+
+	static all() {
+		return games.all().map((item) => new Game(JSON.parse(item.data)));
+	}
+
+	toObject() {
+		return {
+			pid: this.pid,
+			players: this.players,
+			gamestate: this.gamestate,
+		};
+	}
+
+	save() {
+		games.set(this.pid, this.toObject());
+		return this;
+	}
+}
+
+module.exports = {
+	Game,
+};

--- a/lib/Game.js
+++ b/lib/Game.js
@@ -68,6 +68,21 @@ class Game {
 		this.save();
 		return this;
 	}
+
+	moveDisc({ from, to }) {
+		const { board } = this.state;
+		const disc = board.getDisc(from);
+
+		if (!disc) {
+			throw new InvalidMoveError();
+		}
+		if (!board.canMoveDiscTo(from, to)) {
+			throw new IllegalMoveError();
+		}
+		board.moveDisc(from, to);
+		this.save();
+		return this;
+	}
 }
 
 module.exports = {

--- a/lib/Game.js
+++ b/lib/Game.js
@@ -2,19 +2,23 @@ const db = require('quick.db');
 const { nanoid } = require('nanoid');
 const { Board } = require('./Board');
 const { BoardFactory } = require('./BoardFactory');
+const { InvalidMoveError, IllegalMoveError } = require('./Errors');
 
 // eslint-disable-next-line new-cap
 const games = new db.table('games');
 
 class Game {
-	constructor({ pid = nanoid(), players = 2, gamestate = {} }) {
+	constructor({ pid = nanoid(), players = 2, gamestate: state = {} }) {
 		this.pid = pid;
 		this.players = players;
-		this.gamestate = gamestate;
-		if (!gamestate.board) {
-			this.gamestate.board = new Board();
+		this.state = {
+			turn: 0,
+			...state,
+		};
+		if (!state.board) {
+			this.state.board = new Board();
 		} else {
-			this.gamestate.board = BoardFactory.createBoardFromObject(gamestate.board);
+			this.state.board = BoardFactory.createBoardFromObject(state.board);
 		}
 	}
 
@@ -38,14 +42,30 @@ class Game {
 			pid: this.pid,
 			players: this.players,
 			gamestate: {
-				...this.gamestate,
-				board: BoardFactory.toObject(this.gamestate.board),
+				...this.state,
+				board: BoardFactory.toObject(this.state.board),
 			},
 		};
 	}
 
 	save() {
 		games.set(this.pid, this.toObject());
+		return this;
+	}
+
+	moveToken({ from, to }) {
+		const { board } = this.state;
+		const token = board.getToken(from);
+		const currentPlayer = this.state.turn % this.players;
+
+		if (!token || !board.tokenBelongsToPlayer(token, currentPlayer)) {
+			throw new InvalidMoveError();
+		}
+		if (!board.canMoveTokenTo(from, to)) {
+			throw new IllegalMoveError();
+		}
+		board.moveToken(from, to);
+		this.save();
 		return this;
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1360,6 +1360,20 @@
         "picomatch": "^2.0.4"
       }
     },
+    "aproba": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+    },
+    "are-we-there-yet": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+      "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+      "requires": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
+      }
+    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -1695,6 +1709,11 @@
         }
       }
     },
+    "base64-js": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+    },
     "basic-auth": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
@@ -1712,11 +1731,57 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "better-sqlite3": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-6.0.1.tgz",
+      "integrity": "sha512-4aV1zEknM9g1a6B0mVBx1oIlmYioEJ8gSS3J6EpN1b1bKYEE+N5lmpmXHKNKTi0qjHziSd7XrXwHl1kpqvEcHQ==",
+      "requires": {
+        "bindings": "^1.5.0",
+        "integer": "^3.0.1",
+        "prebuild-install": "^5.3.3",
+        "tar": "4.4.10"
+      }
+    },
     "binary-extensions": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
       "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
       "dev": true
+    },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "bl": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
+      "integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
+      "requires": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
     },
     "body-parser": {
       "version": "1.18.3",
@@ -1846,6 +1911,15 @@
       "dev": true,
       "requires": {
         "node-int64": "^0.4.0"
+      }
+    },
+    "buffer": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+      "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+      "requires": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
       }
     },
     "buffer-from": {
@@ -1995,6 +2069,11 @@
         "readdirp": "~3.4.0"
       }
     },
+    "chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
+    },
     "ci-info": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
@@ -2078,6 +2157,11 @@
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
       "dev": true
     },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+    },
     "collect-v8-coverage": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.1.tgz",
@@ -2149,6 +2233,11 @@
       "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.9.tgz",
       "integrity": "sha512-KbS1Y0jMtyPgIxjO7ZzMAuUpAKMt1SzCL9fsrKsX6b0zJPTaT0SiSPmewwVZg9UAO83HVIlEhZF84LIjZ0lmAw==",
       "dev": true
+    },
+    "console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
     },
     "constantinople": {
       "version": "3.1.2",
@@ -2224,8 +2313,7 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cross-spawn": {
       "version": "6.0.5",
@@ -2339,8 +2427,7 @@
     "deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "dev": true
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
     },
     "deep-is": {
       "version": "0.1.3",
@@ -2422,6 +2509,11 @@
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
     },
+    "delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+    },
     "depd": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
@@ -2431,6 +2523,11 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+    },
+    "detect-libc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
     },
     "detect-newline": {
       "version": "3.1.0",
@@ -2536,7 +2633,6 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-      "dev": true,
       "requires": {
         "once": "^1.4.0"
       }
@@ -2881,6 +2977,11 @@
         }
       }
     },
+    "expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="
+    },
     "expect": {
       "version": "26.2.0",
       "resolved": "https://registry.npmjs.org/expect/-/expect-26.2.0.tgz",
@@ -3140,6 +3241,11 @@
         "flat-cache": "^2.0.1"
       }
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
+    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -3236,6 +3342,19 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
+    "fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+    },
+    "fs-minipass": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
+      "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
+      "requires": {
+        "minipass": "^2.6.0"
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -3259,6 +3378,54 @@
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
+    },
+    "gauge": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+      "requires": {
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        }
+      }
     },
     "gensync": {
       "version": "1.0.0-beta.1",
@@ -3301,6 +3468,11 @@
       "requires": {
         "assert-plus": "^1.0.0"
       }
+    },
+    "github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4="
     },
     "glob": {
       "version": "7.1.6",
@@ -3430,6 +3602,11 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
       "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
       "dev": true
+    },
+    "has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
     },
     "has-value": {
       "version": "1.0.0",
@@ -3622,6 +3799,11 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
+    "ieee754": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+    },
     "ienoopen": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/ienoopen/-/ienoopen-1.1.0.tgz",
@@ -3749,8 +3931,7 @@
     "ini": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
-      "dev": true
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
     },
     "inquirer": {
       "version": "7.0.3",
@@ -3771,6 +3952,15 @@
         "string-width": "^4.1.0",
         "strip-ansi": "^5.1.0",
         "through": "^2.3.6"
+      }
+    },
+    "integer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/integer/-/integer-3.0.1.tgz",
+      "integrity": "sha512-OqtER6W2GIJTIcnT5o2B/pWGgvurnVOYs4OZCgay40QEIbMTnNq4R0KSaIw1TZyFtPWjm5aNM+pBBMTfc3exmw==",
+      "requires": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^5.3.3"
       }
     },
     "ip-regex": {
@@ -4032,8 +4222,7 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isexe": {
       "version": "2.0.0",
@@ -6107,8 +6296,24 @@
     "minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+    },
+    "minipass": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
+      "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
+      "requires": {
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.0"
+      }
+    },
+    "minizlib": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
+      "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
+      "requires": {
+        "minipass": "^2.9.0"
+      }
     },
     "mixin-deep": {
       "version": "1.3.2",
@@ -6135,7 +6340,6 @@
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
       "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-      "dev": true,
       "requires": {
         "minimist": "^1.2.5"
       },
@@ -6143,10 +6347,14 @@
         "minimist": {
           "version": "1.2.5",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "dev": true
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
         }
       }
+    },
+    "mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
     },
     "morgan": {
       "version": "1.9.1",
@@ -6170,6 +6378,11 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
+    },
+    "nanoid": {
+      "version": "3.1.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.12.tgz",
+      "integrity": "sha512-1qstj9z5+x491jfiC4Nelk+f8XBad7LN20PmyWINJEMRSf3wcAjAWysw1qaA8z6NSKe2sjq1hRSDpBH5paCb6A=="
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -6198,6 +6411,11 @@
         }
       }
     },
+    "napi-build-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
+      "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg=="
+    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -6219,6 +6437,21 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/nocache/-/nocache-2.1.0.tgz",
       "integrity": "sha512-0L9FvHG3nfnnmaEQPjT9xhfN4ISk0A8/2j4M37Np4mcDesJjHgEUfgPhdCyZuFI954tjokaIj/A3NdpFNdEh4Q=="
+    },
+    "node-abi": {
+      "version": "2.19.1",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.19.1.tgz",
+      "integrity": "sha512-HbtmIuByq44yhAzK7b9j/FelKlHYISKQn0mtvcBrU5QBkhoCMp5bu8Hv5AI34DcKfOAcJBcOEMwLlwO62FFu9A==",
+      "requires": {
+        "semver": "^5.4.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
+      }
     },
     "node-int64": {
       "version": "0.4.0",
@@ -6307,6 +6540,11 @@
         }
       }
     },
+    "noop-logger": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
+      "integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI="
+    },
     "nopt": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
@@ -6356,6 +6594,22 @@
       "requires": {
         "path-key": "^2.0.0"
       }
+    },
+    "npmlog": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "requires": {
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
+      }
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "nwsapi": {
       "version": "2.2.0",
@@ -6479,7 +6733,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -6681,6 +6934,28 @@
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "dev": true
     },
+    "prebuild-install": {
+      "version": "5.3.5",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.5.tgz",
+      "integrity": "sha512-YmMO7dph9CYKi5IR/BzjOJlRzpxGGVo1EsLSUZ0mt/Mq0HWZIHOKHHcHdT69yG54C9m6i45GpItwRHpk0Py7Uw==",
+      "requires": {
+        "detect-libc": "^1.0.3",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp": "^0.5.1",
+        "napi-build-utils": "^1.0.1",
+        "node-abi": "^2.7.0",
+        "noop-logger": "^0.1.1",
+        "npmlog": "^4.0.1",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^3.0.3",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0",
+        "which-pm-runs": "^1.0.0"
+      }
+    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -6731,6 +7006,11 @@
           "dev": true
         }
       }
+    },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "progress": {
       "version": "2.0.3",
@@ -6895,7 +7175,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
       "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-      "dev": true,
       "requires": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -6921,6 +7200,15 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
+    "quick.db": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/quick.db/-/quick.db-7.1.2.tgz",
+      "integrity": "sha512-ItAgjP6CHlC8XN4AAc+K24jDxRmAkkIe5TQp6xyXF5QCCgFlpaknpA3OyLTQ4Dw0c7yq28bcD6SVc7ML/1T/DQ==",
+      "requires": {
+        "better-sqlite3": "^6.0.1",
+        "lodash": "4.17.19"
+      }
+    },
     "range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -6941,7 +7229,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "dev": true,
       "requires": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -6952,14 +7239,12 @@
         "minimist": {
           "version": "1.2.5",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "dev": true
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
         },
         "strip-json-comments": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-          "dev": true
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
         }
       }
     },
@@ -6988,6 +7273,20 @@
       "requires": {
         "find-up": "^2.0.0",
         "read-pkg": "^2.0.0"
+      }
+    },
+    "readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       }
     },
     "readdirp": {
@@ -7477,8 +7776,7 @@
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-      "dev": true
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
     "set-value": {
       "version": "2.0.1",
@@ -7533,8 +7831,37 @@
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-      "dev": true
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+    },
+    "simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="
+    },
+    "simple-get": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.0.tgz",
+      "integrity": "sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==",
+      "requires": {
+        "decompress-response": "^4.2.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      },
+      "dependencies": {
+        "decompress-response": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
+          "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
+          "requires": {
+            "mimic-response": "^2.0.0"
+          }
+        },
+        "mimic-response": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
+          "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA=="
+        }
+      }
     },
     "sisteransi": {
       "version": "1.0.5",
@@ -7885,6 +8212,14 @@
         "function-bind": "^1.1.1"
       }
     },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "strip-ansi": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
@@ -8001,6 +8336,55 @@
             "emoji-regex": "^7.0.1",
             "is-fullwidth-code-point": "^2.0.0",
             "strip-ansi": "^5.1.0"
+          }
+        }
+      }
+    },
+    "tar": {
+      "version": "4.4.10",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.10.tgz",
+      "integrity": "sha512-g2SVs5QIxvo6OLp0GudTqEf05maawKUxXru104iaayWA09551tFCTI8f1Asb4lPfkBr91k07iL4c11XO3/b0tA==",
+      "requires": {
+        "chownr": "^1.1.1",
+        "fs-minipass": "^1.2.5",
+        "minipass": "^2.3.5",
+        "minizlib": "^1.2.1",
+        "mkdirp": "^0.5.0",
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.3"
+      }
+    },
+    "tar-fs": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.0.tgz",
+      "integrity": "sha512-9uW5iDvrIMCVpvasdFHW0wJPez0K4JnMZtsuIeDI7HyMGJNxmDZDOCQROr7lXyS+iL/QMpj07qcjGYTSdRFXUg==",
+      "requires": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.0.0"
+      }
+    },
+    "tar-stream": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.4.tgz",
+      "integrity": "sha512-o3pS2zlG4gxr67GmFYBLlq+dM8gyRGUOvsrHclSkvtVtQbjV0s/+ZE8OpICbaj8clrX3tjeHngYGP7rweaBnuw==",
+      "requires": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
           }
         }
       }
@@ -8150,7 +8534,6 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "dev": true,
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -8401,6 +8784,11 @@
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true
     },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
     "utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -8562,6 +8950,48 @@
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
     },
+    "which-pm-runs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
+      "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs="
+    },
+    "wide-align": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "requires": {
+        "string-width": "^1.0.2 || 2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
+      }
+    },
     "widest-line": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
@@ -8646,8 +9076,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write": {
       "version": "1.0.3",
@@ -8704,6 +9133,11 @@
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
       "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
       "dev": true
+    },
+    "yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
     },
     "yargs": {
       "version": "3.10.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
 		"helmet": "^3.21.2",
 		"http-errors": "~1.6.3",
 		"morgan": "~1.9.1",
-		"pug": "^2.0.4"
+		"nanoid": "^3.1.12",
+		"pug": "^2.0.4",
+		"quick.db": "^7.1.2"
 	},
 	"devDependencies": {
 		"eslint": "^6.8.0",

--- a/routes/api/game.js
+++ b/routes/api/game.js
@@ -7,8 +7,7 @@ module.exports = (router) => {
 	});
 
 	router.put('/games', (req, res, next) => {
-		const game = new Game(req.body);
-		game.save();
+		const game = Game.createNew(req.body);
 		return res.json(game.toObject());
 	});
 

--- a/routes/api/game.js
+++ b/routes/api/game.js
@@ -1,0 +1,19 @@
+const { Game } = require('../../lib/Game');
+
+module.exports = (router) => {
+	router.get('/games', (req, res, next) => {
+		const games = Game.all();
+		return res.json(games.map((game) => game.toObject()));
+	});
+
+	router.put('/games', (req, res, next) => {
+		const game = new Game(req.body);
+		game.save();
+		return res.json(game.toObject());
+	});
+
+	router.get('/games/:pid', (req, res, next) => {
+		const game = Game.getByPid(req.params.pid);
+		return res.json(game);
+	});
+};

--- a/routes/api/index.js
+++ b/routes/api/index.js
@@ -3,15 +3,19 @@ const express = require('express');
 const { Board } = require('../../lib/Board');
 const { BoardFactory } = require('../../lib/BoardFactory');
 
+const initGameRoutes = require('./game');
+
 const router = express.Router();
+initGameRoutes(router);
+
 router.get('/board', (req, res) => {
 	res.json(BoardFactory.toObject(new Board()));
 });
 
 // test route
 router.post('/board', (req, res) => {
-	const foo = req.body.body
-	return res.json({ foo })
+	const foo = req.body.body;
+	return res.json({ foo });
 });
 
 module.exports = router;

--- a/routes/api/index.js
+++ b/routes/api/index.js
@@ -3,6 +3,8 @@ const express = require('express');
 const { Board } = require('../../lib/Board');
 const { BoardFactory } = require('../../lib/BoardFactory');
 
+const { ApplicationError } = require('../../lib/Errors');
+
 const initGameRoutes = require('./game');
 
 const router = express.Router();
@@ -16,6 +18,24 @@ router.get('/board', (req, res) => {
 router.post('/board', (req, res) => {
 	const foo = req.body.body;
 	return res.json({ foo });
+});
+
+router.use((err, req, res, next) => {
+	if (err instanceof ApplicationError) {
+		res.status(err.status()).json({
+			error: err.constructor.name,
+			message: err.message,
+			status: err.status(),
+			request: {
+				method: req.method,
+				route: req.route.path,
+				params: req.params,
+				data: req.body,
+			},
+		});
+	} else {
+		next(err);
+	}
 });
 
 module.exports = router;

--- a/routes/api/index.js
+++ b/routes/api/index.js
@@ -6,9 +6,17 @@ const { BoardFactory } = require('../../lib/BoardFactory');
 const { ApplicationError } = require('../../lib/Errors');
 
 const initGameRoutes = require('./game');
+const initMoveRoutes = require('./move');
 
 const router = express.Router();
+
+router.use((req, res, next) => {
+	res.locals.pid = '3gj9DLW9yQGIA2lU0BaW_';
+	next();
+});
+
 initGameRoutes(router);
+initMoveRoutes(router);
 
 router.get('/board', (req, res) => {
 	res.json(BoardFactory.toObject(new Board()));

--- a/routes/api/move.js
+++ b/routes/api/move.js
@@ -1,0 +1,17 @@
+const { Game } = require('../../lib/Game');
+
+module.exports = (router) => {
+	router.post('/moveToken', (req, res, next) => {
+		try {
+			const { pid } = res.locals;
+			const game = Game.getByPid(pid);
+			game.moveToken({
+				from: req.body.from,
+				to: req.body.to,
+			});
+			return res.json(game.toObject());
+		} catch (err) {
+			return next(err);
+		}
+	});
+};

--- a/routes/api/move.js
+++ b/routes/api/move.js
@@ -14,4 +14,18 @@ module.exports = (router) => {
 			return next(err);
 		}
 	});
+
+	router.post('/moveDisc', (req, res, next) => {
+		try {
+			const { pid } = res.locals;
+			const game = Game.getByPid(pid);
+			game.moveDisc({
+				from: req.body.from,
+				to: req.body.to,
+			});
+			return res.json(game.toObject());
+		} catch (err) {
+			return next(err);
+		}
+	});
 };


### PR DESCRIPTION
This adds a miniature database layer, global API error handling, some basic use cases around games and moves, and the corresponding API:

- `PUT  /api/games` creates a game
- `GET  /api/games` lists all games
- `GET  /api/games/:id` returns the game with given id
- `POST /api/moveToken` (post data `{from: {x, y}, to: {x, y}}`)
- `POST /api/moveDisc` moves a disc (post data `{from: {x, y}, to: {x, y}}`)

For now, there is a middleware that simulates getting the id of the current game from a cookie or session by always returning the same id. This will change. API docs will follow.