### PR TITLE
Add dots to represent that disc can be moved

### DIFF
--- a/lib/Game.js
+++ b/lib/Game.js
@@ -15,7 +15,7 @@ const PHASES = Object.freeze({
 class Game {
 	constructor({
 		pid = nanoid(),
-		players = this.players || ['Max', 'Tor'],
+		players = ['Max', 'Tor'],
 		friendlyName = 'My Yesnaga Game',
 		gamestate: state = {},
 	}) {

--- a/lib/Game.js
+++ b/lib/Game.js
@@ -15,7 +15,7 @@ const PHASES = Object.freeze({
 class Game {
 	constructor({
 		pid = nanoid(),
-		players = ['Max', 'Tor'],
+		players = this.players || ['Max', 'Tor'],
 		friendlyName = 'My Yesnaga Game',
 		gamestate: state = {},
 	}) {

--- a/public/scripts/fetch.js
+++ b/public/scripts/fetch.js
@@ -1,6 +1,6 @@
 /* const baseUrl = process.env.NODE_ENV === 'production'
-    ? '/api'
-    : `http://${window.location.hostname}:3000/api`
+	? '/api'
+	: `http://${window.location.hostname}:3000/api`
  */
 
 const errHandler = (err) => {
@@ -39,9 +39,6 @@ const updateBoard = (body) => {
 				return response.json();
 			}
 			throw new Error('Request failed.');
-		})
-		.then((data) => {
-			console.log(data, 'data');
 		})
 		.catch(errHandler);
 };

--- a/public/scripts/game.js
+++ b/public/scripts/game.js
@@ -21,10 +21,15 @@ class Game {
 	replaceBoard(board) {
 		this.tokens = [];
 		this.discs = [];
+		this.ghostDiscs = []
 		this.playerTokens = board.players;
+
+		const tempGhostDiscs = []
 
 		board.discs.forEach((d) => {
 			this.discs.push(new Disc(d.x * 120 + (d.y * -60) + 500, d.y * 100 + 500, 80, d));
+
+			d.moveableTo.forEach(ghostDisc => tempGhostDiscs.push(new GhostDisc(ghostDisc.x * 120 + (ghostDisc.y * -60) + 500, ghostDisc.y * 100 + 500, 80, ghostDisc)))
 
 			this.playerTokens.forEach((player) => {
 				const token = player.tokens.find((t) => t.tile.x === d.x && t.tile.y === d.y);
@@ -33,6 +38,8 @@ class Game {
 				}
 			});
 		});
+		const uniqueGhostDiscs = new Set(tempGhostDiscs.map(gh => JSON.stringify(gh)));
+		this.ghostDiscs = Array.from(uniqueGhostDiscs).map(ghostDisc => JSON.parse(ghostDisc))
 	}
 
 	getPlayerTurn() {

--- a/public/scripts/game.js
+++ b/public/scripts/game.js
@@ -8,8 +8,14 @@ class Game {
 		this.debug = false;
 		this.players = data.players;
 
+		// temp variable
+		this.phase = /* data.gamestate.phase || */ 'mid_move' // enum: ["mid_move", "initial"]
 		this.replaceBoard(data.gamestate.board);
 		this.hud = new Hud(this);
+	}
+
+	setPhase(phase) {
+		this.phase = phase
 	}
 
 	replaceBoard(board) {
@@ -104,6 +110,7 @@ class Game {
 			tile.clicked = false;
 		}
 		for (const disc of this.discs) {
+			disc.clicked = false;
 			disc.previewMode = false;
 		}
 	}
@@ -123,6 +130,7 @@ class Game {
 				.then((result) => {
 					if (result) {
 						this.replaceBoard(result)
+						// this.setPhase(result)
 					}
 				})
 				.catch(errorHandler);
@@ -130,6 +138,7 @@ class Game {
 		this.resetClick();
 
 		const token = this.tokens.find((t) => t.hovering);
+		const disc = this.discs.find((d) => d.hovering)
 
 		if (token) {
 			token.clicked = !token.clicked;
@@ -140,6 +149,10 @@ class Game {
 					targetDisc.previewMode = true;
 				}
 			});
+		}
+
+		if (disc && this.phase === 'mid_move') {
+			disc.clicked = !disc.clicked;
 		}
 	}
 }

--- a/public/scripts/game.js
+++ b/public/scripts/game.js
@@ -24,12 +24,12 @@ class Game {
 		this.ghostDiscs = []
 		this.playerTokens = board.players;
 
-		const tempGhostDiscs = []
+		const uniqueGhostDiscs = new Set();
 
 		board.discs.forEach((d) => {
 			this.discs.push(new Disc(d.x * 120 + (d.y * -60) + 500, d.y * 100 + 500, 80, d));
 
-			d.moveableTo.forEach(ghostDisc => tempGhostDiscs.push(new GhostDisc(ghostDisc.x * 120 + (ghostDisc.y * -60) + 500, ghostDisc.y * 100 + 500, 80, ghostDisc)))
+			d.moveableTo.forEach(ghostDisc => uniqueGhostDiscs.add(JSON.stringify(ghostDisc)))
 
 			this.playerTokens.forEach((player) => {
 				const token = player.tokens.find((t) => t.tile.x === d.x && t.tile.y === d.y);
@@ -38,8 +38,9 @@ class Game {
 				}
 			});
 		});
-		const uniqueGhostDiscs = new Set(tempGhostDiscs.map(gh => JSON.stringify(gh)));
-		this.ghostDiscs = Array.from(uniqueGhostDiscs).map(ghostDisc => JSON.parse(ghostDisc))
+		this.ghostDiscs = Array.from(uniqueGhostDiscs)
+			.map(ghostDisc => JSON.parse(ghostDisc))
+			.map(ghostDisc => new GhostDisc(ghostDisc.x * 120 + (ghostDisc.y * -60) + 500, ghostDisc.y * 100 + 500, 80, ghostDisc))
 	}
 
 	getPlayerTurn() {
@@ -64,6 +65,11 @@ class Game {
 			token.hovering = this.tileHoverCheck(token, mouseX, mouseY);
 			token.draw();
 		});
+		if (this.phase === 'mid_move') {
+			this.ghostDiscs.forEach((ghostDisc) => {
+				ghostDisc.draw();
+			})
+		}
 		if (this.errorMsg) {
 			fill('tomato');
 			text(`${this.errorMsg}`, 25, 150);

--- a/public/scripts/game.js
+++ b/public/scripts/game.js
@@ -150,8 +150,8 @@ class Game {
 
 	mouseClicked(e) {
 		const clickedToken = this.tokens.find((t) => t.clicked);
-		const hoveringDisc = this.discs.find((d) => d.hovering);
 		const hoveringToken = this.tokens.find((t) => t.hovering);
+		const hoveringDisc = this.discs.find((d) => d.hovering);
 		if (this.phase === 'initial') {
 			return this.mouseClickInitialPhase(clickedToken, hoveringDisc, hoveringToken)
 		}

--- a/public/scripts/index.js
+++ b/public/scripts/index.js
@@ -1,1 +1,0 @@
-console.log('hello world');

--- a/public/scripts/main.js
+++ b/public/scripts/main.js
@@ -9,6 +9,7 @@ function preload() {
 
 function setup() {
 	createCanvas(1200, 1000);
+	frameRate(20)
 	game.setup();
 }
 

--- a/public/scripts/main.js
+++ b/public/scripts/main.js
@@ -1,6 +1,8 @@
+
 let game;
 
 function preload() {
+	menu = new Menu()
 	// todo: somehow select the game or create a new one to get a real pid
 	loadJSON('/api/games/3gj9DLW9yQGIA2lU0BaW_', (result) => {
 		game = new Game(result);
@@ -21,5 +23,5 @@ function keyPressed() {
 	game.cheatCode(key);
 }
 function mouseClicked(e) {
-	game.clickTile(e);
+	game.mouseClicked(e);
 }

--- a/public/scripts/main.js
+++ b/public/scripts/main.js
@@ -11,7 +11,7 @@ function preload() {
 
 function setup() {
 	createCanvas(1200, 1000);
-	frameRate(20)
+	//frameRate(20)
 	game.setup();
 }
 

--- a/public/scripts/menu.js
+++ b/public/scripts/menu.js
@@ -1,0 +1,30 @@
+
+
+class Menu {
+    constructor() {
+        this.player1 = ''
+        this.player2 = ''
+        this.showInstructions = false
+    }
+    setup() {
+    }
+
+    draw() {
+        this.drawTitle()
+        if (this.showInstructions) {
+            this.drawInstructions()
+        }
+    }
+
+    drawTitle() {
+        text('NONAGA', 100, 100)
+    }
+    drawInstructions() {
+        text('Instructions: xyz', 200, 200)
+    }
+
+    // new game
+    // continue game
+    // instructions
+    // github link?
+}

--- a/public/scripts/menu.js
+++ b/public/scripts/menu.js
@@ -17,7 +17,7 @@ class Menu {
     }
 
     drawTitle() {
-        text('NONAGA', 100, 100)
+        text('YESNAGA', 100, 100)
     }
     drawInstructions() {
         text('Instructions: xyz', 200, 200)

--- a/public/shapes/disc.js
+++ b/public/shapes/disc.js
@@ -22,11 +22,11 @@ class Disc {
 		ellipse(this.x, this.y, this.d);
 
 		if (game.phase === 'mid_move' && this.discInfo.moveable) {
-			const dotWeight = this.hovering || this.clicked ? 2.8 : 2
+			const dotWeight = this.hovering || this.clicked ? 3.5 : 2
 			fill('black')
 			for (let i = 0; i < 3; i++) {
 				for (let j = 0; j < 2; j++) {
-					ellipse(this.x - 6 + i * 6, this.y + j * 6, dotWeight);
+					ellipse(this.x - 8 + i * 8, this.y + j * 8, dotWeight);
 				}
 			}
 			fill('#e5e5e5');

--- a/public/shapes/disc.js
+++ b/public/shapes/disc.js
@@ -26,19 +26,12 @@ class Disc {
 			fill('black')
 			for (let i = 0; i < 3; i++) {
 				for (let j = 0; j < 2; j++) {
-					ellipse(this.x - 8 + i * 8, this.y + j * 8, dotWeight);
+					ellipse(this.x - 8 + i * 8, this.y - 2 + j * 8, dotWeight);
 				}
 			}
 			fill('#e5e5e5');
 		}
-		if (this.clicked) {
-			// disc is now clicked
-		}
-		// debug
-		if (game.debug) {
-			fill('black');
-			textSize(20);
-			text(`ID:${this.discInfo.id}`, this.x - 25, this.y + 5);
-		}
+
+
 	}
 }

--- a/public/shapes/disc.js
+++ b/public/shapes/disc.js
@@ -5,17 +5,14 @@ class Disc {
 		this.d = d;
 		this.discInfo = discInfo;
 
+		this.clicked = false;
 		this.hovering = false;
 		this.previewMode = false;
 	}
-
-	static colors() {
+	// uneeded variables?
+	/* static colors() {
 		return ['#F79B18', '#00ADEF'];
-	}
-
-	setup() {
-		return false;
-	}
+	} */
 
 	draw() {
 		fill('#e5e5e5');
@@ -24,6 +21,19 @@ class Disc {
 		}
 		ellipse(this.x, this.y, this.d);
 
+		if (game.phase === 'mid_move' && this.discInfo.moveable) {
+			const dotWeight = this.hovering || this.clicked ? 2.8 : 2
+			fill('black')
+			for (let i = 0; i < 3; i++) {
+				for (let j = 0; j < 2; j++) {
+					ellipse(this.x - 6 + i * 6, this.y + j * 6, dotWeight);
+				}
+			}
+			fill('#e5e5e5');
+		}
+		if (this.clicked) {
+			// disc is now clicked
+		}
 		// debug
 		if (game.debug) {
 			fill('black');

--- a/public/shapes/ghostDisc.js
+++ b/public/shapes/ghostDisc.js
@@ -1,0 +1,20 @@
+class GhostDisc {
+    constructor(x, y, d = 80, discInfo) {
+        this.x = x;
+        this.y = y;
+        this.d = d;
+        this.discInfo = discInfo;
+
+        this.clicked = false;
+        this.hovering = false;
+    }
+    // uneeded variables?
+    /* static colors() {
+        return ['#F79B18', '#00ADEF'];
+    } */
+
+    draw() {
+        fill('tomato');
+
+    }
+}

--- a/public/shapes/ghostDisc.js
+++ b/public/shapes/ghostDisc.js
@@ -7,6 +7,7 @@ class GhostDisc {
 
         this.clicked = false;
         this.hovering = false;
+        this.display = false
     }
     // uneeded variables?
     /* static colors() {
@@ -14,7 +15,10 @@ class GhostDisc {
     } */
 
     draw() {
-        fill('tomato');
+        if (!this.display) {
+            fill('rgba(225, 225, 225, 0.2)')
+            ellipse(this.x, this.y, this.d);
+        }
 
     }
 }

--- a/public/shapes/ghostDisc.js
+++ b/public/shapes/ghostDisc.js
@@ -5,20 +5,19 @@ class GhostDisc {
         this.d = d;
         this.discInfo = discInfo;
 
-        this.clicked = false;
+        //this.clicked = false;
         this.hovering = false;
         this.display = false
     }
-    // uneeded variables?
-    /* static colors() {
-        return ['#F79B18', '#00ADEF'];
-    } */
 
     draw() {
-        if (!this.display) {
-            fill('rgba(225, 225, 225, 0.2)')
+        if (this.display) {
+            fill('rgba(220, 220, 220, 0.24)')
+            if (!this.hovering) {
+                noStroke()
+            }
             ellipse(this.x, this.y, this.d);
+            stroke('black')
         }
-
     }
 }

--- a/public/shapes/hud.js
+++ b/public/shapes/hud.js
@@ -14,7 +14,7 @@ class Hud {
 		];
 	}
 
-	setup() {}
+	setup() { }
 
 	draw() {
 		textSize(20);

--- a/public/shapes/hud.js
+++ b/public/shapes/hud.js
@@ -1,3 +1,8 @@
+const hints = {
+	initial: 'token',
+	mid_move: 'disc'
+}
+
 class Hud {
 	constructor(game) {
 		this.game = game;
@@ -14,9 +19,8 @@ class Hud {
 		];
 	}
 
-	setup() { }
-
 	draw() {
+		noStroke()
 		textSize(20);
 		fill('#BBB');
 		text('Player turn:', 25, 30);
@@ -25,5 +29,13 @@ class Hud {
 		fill(this.playerInformation[currentPlayer].color);
 		text(this.playerInformation[currentPlayer].name, 25, 60);
 		ellipse(10, 50, 15);
+
+		// draws hints in start phase
+		if (game.gameHistory.length < 3) {
+			fill('#BBB');
+			textSize(map(sin(frameCount * 0.02), -20, 1, 45, 25));
+			text(`Move a ${hints[game.phase]}`, 25, 120)
+		}
+		stroke("black")
 	}
 }

--- a/public/shapes/token.js
+++ b/public/shapes/token.js
@@ -28,12 +28,5 @@ class Token {
 		}
 		ellipse(this.x, this.y, this.d);
 		strokeWeight(1);
-
-		// debug
-		if (game.debug) {
-			fill('black');
-			textSize(20);
-			text(`P${this.player}`, this.x - 25, this.y + 5);
-		}
 	}
 }

--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -1,16 +1,17 @@
+*{
+  margin:0;
+  padding:0
+}
+
+canvas{
+  margin-top: 2%;
+  margin-left: 2%;
+}
+
 body {
-  padding: 50px;
   font: 14px "Lucida Grande", Helvetica, Arial, sans-serif;
 }
 
 a {
   color: #00B7FF;
-}
-
-.debug-toggle {
-  display: inline;
-}
-
-.debug-toggle > label {
-  cursor: pointer;
 }

--- a/views/board.pug
+++ b/views/board.pug
@@ -9,7 +9,7 @@ block content
   script(src="shapes/ghostDisc.js")
   script(src="shapes/hud.js")
   script(src="shapes/background.js")
+  script(src="scripts/menu.js")
   script(src="scripts/game.js")
   script(src="scripts/main.js")
   #board
-  include debug-toggle

--- a/views/board.pug
+++ b/views/board.pug
@@ -6,6 +6,7 @@ block content
   script(src="scripts/constants.js")
   script(src="shapes/disc.js")
   script(src="shapes/token.js")
+  script(src="shapes/ghostDisc.js")
   script(src="shapes/hud.js")
   script(src="shapes/background.js")
   script(src="scripts/game.js")

--- a/views/debug-toggle.pug
+++ b/views/debug-toggle.pug
@@ -1,7 +1,0 @@
-.debug-toggle
-	label
-		input(
-			type='checkbox'
-			onclick='game.debug = !game.debug'
-		)
-		| Debug


### PR DESCRIPTION
[YES-6](https://app.gitkraken.com/glo/view/card/5c865d947ec843cca3a6cde9e1a580be)

- Added dots that expands on hover || clicked.
- Shows ghost discs with alpha/transparency when moveable disc is clicked
- removed hovering from player discs when phase is in mid_move
- Phase is now set for every move that is being made
- adjusted framerate from default and down to 20. This cause a eyesore when looking at the 'lagging' sun in Background
- Add state in Hud class to indicate what player should do next (for the first 3 moves)


