### PR TITLE
Add tests to game use cases and fix movement of discs

### DIFF
--- a/lib/Board.js
+++ b/lib/Board.js
@@ -239,19 +239,23 @@ class Board {
 			// starting at the disc tile, find all discs that have
 			// less than six neighbours and are not the disc to be moved
 			coordinates,
-			(disc) => Object.keys(this.getNeighbours(disc)).length !== 6 && disc.id !== thisDisc.id,
+			(disc) => Object.keys(this.getNeighbours(disc)).length < 6 && disc.id !== thisDisc.id,
 		);
-		const results = new Map();
+		const results = new Set();
+		const seen = new Set();
 		outerDiscs.forEach((discId) => {
 			const disc = this.discById[discId];
 			allDirections.forEach((direction) => {
 				const position = getCoordinateModifier(direction)(disc);
 				if (!this.getDisc(position)) {
-					results.set(`x${position.x}y${position.y}`, position);
+					const key = `x${position.x}y${position.y}`;
+					// only allow target positions which neighbor at least two discs
+					if (seen.has(key)) results.add(position);
+					seen.add(key);
 				}
 			});
 		});
-		return Array.from(results.values());
+		return Array.from(results);
 	}
 
 	/**

--- a/lib/Board.test.js
+++ b/lib/Board.test.js
@@ -388,14 +388,19 @@ describe('Board', () => {
 
 	describe('#getDiscMoveTargets', () => {
 		it('should return all outer discs with all missing neighbours', () => {
-			expect(theBoard.getDiscMoveTargets({ x: 0, y: 0 }).length).toStrictEqual(18);
+			// This is basically every position boardering the board, except for
+			// the positions next to each of the six corners, where the disc cannot
+			// be moved to, because it would touch only one disc: 18 positions - 6 corners
+			expect(theBoard.getDiscMoveTargets({ x: 0, y: 0 }).length).toStrictEqual(12);
 		});
 
 		it('should exclude moving a disc to its current position', () => {
-			// outer disc with three missing neighbours
-			expect(theBoard.getDiscMoveTargets({ x: 0, y: 2 }).length).toStrictEqual(17);
-			// outer disc with two missing neighbours
-			expect(theBoard.getDiscMoveTargets({ x: 1, y: 2 }).length).toStrictEqual(18);
+			// Outer disc with three missing neighbours. This eliminates two potential
+			// positions, which would have been suitable before taking the disc away
+			expect(theBoard.getDiscMoveTargets({ x: 0, y: 2 }).length).toStrictEqual(10);
+			// Outer disc with two missing neighbours. Again, this eliminates two
+			// potential targets, which would have been suitable before taking the disc away
+			expect(theBoard.getDiscMoveTargets({ x: 1, y: 2 }).length).toStrictEqual(10);
 		});
 
 		it('should return coordinates for all candidates', () => {
@@ -410,8 +415,8 @@ describe('Board', () => {
 	describe('#canMoveDiscTo', () => {
 		it('returns true for valid moves', () => {
 			expect(theBoard.canMoveDiscTo({ x: -2, y: -1 }, { x: -2, y: 1 })).toBe(true);
-			expect(theBoard.canMoveDiscTo({ x: 1, y: 2 }, { x: 0, y: 3 })).toBe(true);
-			expect(theBoard.canMoveDiscTo({ x: 1, y: -1 }, { x: -3, y: -3 })).toBe(true);
+			expect(theBoard.canMoveDiscTo({ x: 1, y: 2 }, { x: -1, y: 2 })).toBe(true);
+			expect(theBoard.canMoveDiscTo({ x: 1, y: -1 }, { x: -3, y: -2 })).toBe(true);
 		});
 
 		it('returns false for unmoveable discs', () => {
@@ -423,6 +428,11 @@ describe('Board', () => {
 			expect(theBoard.canMoveDiscTo({ x: -2, y: -1 }, { x: -5, y: 1 })).toBe(false);
 			expect(theBoard.canMoveDiscTo({ x: 1, y: 2 }, { x: 0, y: 2 })).toBe(false);
 			expect(theBoard.canMoveDiscTo({ x: 1, y: -1 }, { x: 0, y: 0 })).toBe(false);
+		});
+
+		it('returns false if the target is connected to fewer than two discs', () => {
+			expect(theBoard.canMoveDiscTo({ x: 1, y: 2 }, { x: -1, y: 3 })).toBe(false);
+			expect(theBoard.canMoveDiscTo({ x: 1, y: -1 }, { x: -3, y: -3 })).toBe(false);
 		});
 	});
 

--- a/lib/Errors.js
+++ b/lib/Errors.js
@@ -13,9 +13,14 @@ class IllegalMoveError extends InvalidInputError {
 	constructor(message = 'The given move is not possible.') { super(message); }
 }
 
+class NotFoundError extends ApplicationError {
+	status() { return 404; }
+}
+
 module.exports = {
 	ApplicationError,
 	InvalidInputError,
 	InvalidMoveError,
 	IllegalMoveError,
+	NotFoundError,
 };

--- a/lib/Game.js
+++ b/lib/Game.js
@@ -1,7 +1,7 @@
 const { nanoid } = require('nanoid');
 const { Board } = require('./Board');
 const { BoardFactory } = require('./BoardFactory');
-const { InvalidMoveError, IllegalMoveError } = require('./Errors');
+const { InvalidMoveError, IllegalMoveError, NotFoundError } = require('./Errors');
 const { GameModel } = require('./models/Games.model');
 
 const PHASES = Object.freeze({
@@ -40,6 +40,9 @@ module.exports = (Model = new GameModel()) => {
 
 		static getByPid(pid) {
 			const game = Model.get(pid);
+			if (!game) {
+				throw new NotFoundError(`No game found with pid=${pid}.`);
+			}
 			return new Game(game);
 		}
 

--- a/lib/Game.js
+++ b/lib/Game.js
@@ -106,5 +106,5 @@ module.exports = (Model = new GameModel()) => {
 		}
 	}
 
-	return { Game };
+	return { Game, GamePhases: PHASES };
 };

--- a/lib/Game.js
+++ b/lib/Game.js
@@ -1,110 +1,107 @@
-const db = require('quick.db');
 const { nanoid } = require('nanoid');
 const { Board } = require('./Board');
 const { BoardFactory } = require('./BoardFactory');
 const { InvalidMoveError, IllegalMoveError } = require('./Errors');
-
-// eslint-disable-next-line new-cap
-const games = new db.table('games');
+const { GameModel } = require('./models/Games.model');
 
 const PHASES = Object.freeze({
 	INITIAL: 'initial',
 	MID_MOVE: 'mid_move',
 });
 
-class Game {
-	constructor({
-		pid = nanoid(),
-		players = ['Max', 'Tor'],
-		friendlyName = 'My Yesnaga Game',
-		gamestate: state = {},
-	}) {
-		this.pid = pid;
-		this.players = players;
-		this.friendlyName = friendlyName;
-		this.state = {
-			turn: 0,
-			phase: PHASES.INITIAL,
-			...state,
-		};
-		if (!state.board) {
-			this.state.board = new Board();
-		} else {
-			this.state.board = BoardFactory.createBoardFromObject(state.board);
+module.exports = (Model = new GameModel()) => {
+	class Game {
+		constructor({
+			pid = nanoid(),
+			players = ['Max', 'Tor'],
+			friendlyName = 'My Yesnaga Game',
+			gamestate: state = {},
+		}) {
+			this.pid = pid;
+			this.players = players;
+			this.friendlyName = friendlyName;
+			this.state = {
+				turn: 0,
+				phase: PHASES.INITIAL,
+				...state,
+			};
+			if (!state.board) {
+				this.state.board = new Board();
+			} else {
+				this.state.board = BoardFactory.createBoardFromObject(state.board);
+			}
+		}
+
+		static createNew(data) {
+			const game = new Game(data);
+			game.save();
+			return game;
+		}
+
+		static getByPid(pid) {
+			const game = Model.get(pid);
+			return new Game(game);
+		}
+
+		static all() {
+			return Model.all().map((item) => new Game(item));
+		}
+
+		toObject() {
+			return {
+				pid: this.pid,
+				players: this.players,
+				friendlyName: this.friendlyName,
+				gamestate: {
+					...this.state,
+					board: BoardFactory.toObject(this.state.board),
+				},
+			};
+		}
+
+		save() {
+			Model.set(this.pid, this.toObject());
+			return this;
+		}
+
+		moveToken({ from, to }) {
+			const { board } = this.state;
+			const token = board.getToken(from);
+			const currentPlayer = this.state.turn % this.players.length;
+
+			if (
+				!token
+				|| this.state.phase !== PHASES.INITIAL
+				|| !board.tokenBelongsToPlayer(token, currentPlayer)
+			) {
+				throw new InvalidMoveError();
+			}
+			if (!board.canMoveTokenTo(from, to)) {
+				throw new IllegalMoveError();
+			}
+			board.moveToken(from, to);
+			this.state.phase = PHASES.MID_MOVE;
+			this.save();
+			return this;
+		}
+
+		moveDisc({ from, to }) {
+			const { board } = this.state;
+			const disc = board.getDisc(from);
+
+			if (!disc || this.state.phase !== PHASES.MID_MOVE) {
+				throw new InvalidMoveError();
+			}
+			if (!board.canMoveDiscTo(from, to)) {
+				throw new IllegalMoveError();
+			}
+			board.moveDisc(from, to);
+			this.state.phase = PHASES.INITIAL;
+			this.state.turn += 1;
+			this.save();
+			return this;
 		}
 	}
 
-	static createNew(data) {
-		const game = new Game(data);
-		game.save();
-		return game;
-	}
-
-	static getByPid(pid) {
-		const game = games.get(pid);
-		return new Game(game);
-	}
-
-	static all() {
-		return games.all().map((item) => new Game(JSON.parse(item.data)));
-	}
-
-	toObject() {
-		return {
-			pid: this.pid,
-			players: this.players,
-			friendlyName: this.friendlyName,
-			gamestate: {
-				...this.state,
-				board: BoardFactory.toObject(this.state.board),
-			},
-		};
-	}
-
-	save() {
-		games.set(this.pid, this.toObject());
-		return this;
-	}
-
-	moveToken({ from, to }) {
-		const { board } = this.state;
-		const token = board.getToken(from);
-		const currentPlayer = this.state.turn % this.players.length;
-
-		if (
-			!token
-			|| this.state.phase !== PHASES.INITIAL
-			|| !board.tokenBelongsToPlayer(token, currentPlayer)
-		) {
-			throw new InvalidMoveError();
-		}
-		if (!board.canMoveTokenTo(from, to)) {
-			throw new IllegalMoveError();
-		}
-		board.moveToken(from, to);
-		this.state.phase = PHASES.MID_MOVE;
-		this.save();
-		return this;
-	}
-
-	moveDisc({ from, to }) {
-		const { board } = this.state;
-		const disc = board.getDisc(from);
-
-		if (!disc || this.state.phase !== PHASES.MID_MOVE) {
-			throw new InvalidMoveError();
-		}
-		if (!board.canMoveDiscTo(from, to)) {
-			throw new IllegalMoveError();
-		}
-		board.moveDisc(from, to);
-		this.state.phase = PHASES.INITIAL;
-		this.state.turn += 1;
-		this.save();
-		return this;
-	}
-}
-
-module.exports = {
-	Game,
+	return { Game };
 };

--- a/lib/Game.test.js
+++ b/lib/Game.test.js
@@ -93,5 +93,24 @@ describe('Game', () => {
 				expect(obj.friendlyName).toEqual('Mein Yesnaga-Spiel');
 			});
 		});
+
+		describe('#save', () => {
+			it('creates a game in the model', () => {
+				const game = new Game({
+					pid: 'savegame',
+					friendlyName: 'should be saved',
+				});
+				expect(mock.count()).toEqual(0);
+				game.save();
+				expect(mock.count()).toEqual(1);
+				expect(mock.data[game.pid].pid).toEqual(game.pid);
+				expect(mock.data[game.pid].friendlyName).toEqual(game.friendlyName);
+			});
+
+			it('returns the game instance', () => {
+				const game = new Game({});
+				expect(game.save()).toEqual(game);
+			});
+		});
 	});
 });

--- a/lib/Game.test.js
+++ b/lib/Game.test.js
@@ -1,5 +1,6 @@
 const gameModule = require('./Game');
 const { GamesModelMock } = require('./models/Games.mock');
+const { NotFoundError } = require('./Errors');
 
 describe('Game', () => {
 	describe('dependency injection', () => {
@@ -16,15 +17,44 @@ describe('Game', () => {
 	});
 
 	describe('use cases', () => {
+		let mock;
+		let Game;
+
+		beforeEach(() => {
+			mock = new GamesModelMock();
+			// eslint-disable-next-line prefer-destructuring
+			Game = gameModule(mock).Game;
+		});
+
 		describe('#createNew', () => {
 			it('creates a new game and returns it after persisting to the model', () => {
-				const mock = new GamesModelMock();
-				const { Game } = gameModule(mock);
 				expect(mock.count()).toEqual(0);
 
 				const game = Game.createNew({});
 				expect(mock.count()).toEqual(1);
 				expect(game).toBeInstanceOf(Game);
+			});
+
+			it('assignes default values if not given', () => {
+				const game = Game.createNew({});
+				expect(game.friendlyName).toEqual('My Yesnaga Game');
+				expect(game.players.length).toEqual(2);
+				expect(game.state.turn).toEqual(0);
+			});
+		});
+
+		describe('#getByPid', () => {
+			it('returns a game based on its public id', () => {
+				const game1 = Game.createNew({ pid: 'foo' });
+				const game2 = Game.createNew({ pid: 'bar' });
+				const game3 = Game.createNew({ pid: 'baz' });
+				expect(Game.getByPid('foo')).toEqual(game1);
+				expect(Game.getByPid('baz')).toEqual(game3);
+				expect(Game.getByPid('bar')).toEqual(game2);
+			});
+
+			it('throws an error if the game does not exist', () => {
+				expect(() => Game.getByPid('doesnotexist')).toThrow(NotFoundError);
 			});
 		});
 	});

--- a/lib/Game.test.js
+++ b/lib/Game.test.js
@@ -57,5 +57,41 @@ describe('Game', () => {
 				expect(() => Game.getByPid('doesnotexist')).toThrow(NotFoundError);
 			});
 		});
+
+		describe('#toObject', () => {
+			it('returns an object representation of a game', () => {
+				const game = new Game({});
+				const obj = game.toObject();
+				expect(obj).toBeInstanceOf(Object);
+				expect(JSON.parse(JSON.stringify(obj))).toStrictEqual(obj);
+			});
+
+			it('contains pid, players, friendlyName, and gamestate', () => {
+				const game = new Game({});
+				const obj = game.toObject();
+				['pid', 'players', 'friendlyName', 'gamestate'].forEach((property) => {
+					expect(Object.prototype.hasOwnProperty.call(obj, property)).toEqual(true);
+				});
+			});
+
+			it('serializes the game\'s state and board', () => {
+				const game = new Game({ gamestate: { turn: 4 } });
+				const obj = game.toObject();
+				expect(obj.gamestate.turn).toEqual(4);
+				expect(Object.prototype.hasOwnProperty.call(obj.gamestate, 'board')).toEqual(true);
+			});
+
+			it('works for custom values', () => {
+				const game = new Game({
+					pid: 'foobar',
+					players: ['me', 'you', 'him'],
+					friendlyName: 'Mein Yesnaga-Spiel',
+				});
+				const obj = game.toObject();
+				expect(obj.pid).toEqual('foobar');
+				expect(new Set(obj.players)).toStrictEqual(new Set(['me', 'you', 'him']));
+				expect(obj.friendlyName).toEqual('Mein Yesnaga-Spiel');
+			});
+		});
 	});
 });

--- a/lib/Game.test.js
+++ b/lib/Game.test.js
@@ -1,6 +1,6 @@
 const gameModule = require('./Game');
 const { GamesModelMock } = require('./models/Games.mock');
-const { NotFoundError } = require('./Errors');
+const { NotFoundError, InvalidMoveError, IllegalMoveError } = require('./Errors');
 
 describe('Game', () => {
 	describe('dependency injection', () => {
@@ -19,11 +19,15 @@ describe('Game', () => {
 	describe('use cases', () => {
 		let mock;
 		let Game;
+		let GamePhases;
 
 		beforeEach(() => {
 			mock = new GamesModelMock();
+			const instance = gameModule(mock);
 			// eslint-disable-next-line prefer-destructuring
-			Game = gameModule(mock).Game;
+			Game = instance.Game;
+			// eslint-disable-next-line prefer-destructuring
+			GamePhases = instance.GamePhases;
 		});
 
 		describe('#createNew', () => {
@@ -110,6 +114,126 @@ describe('Game', () => {
 			it('returns the game instance', () => {
 				const game = new Game({});
 				expect(game.save()).toEqual(game);
+			});
+		});
+
+		describe('#moveToken', () => {
+			it('allows valid moves', () => {
+				const game = new Game({});
+				expect(() => game.moveToken({ from: { x: -2, y: 0 }, to: { x: -2, y: -1 } }))
+					.not.toThrow();
+				expect(game.state.board.getToken({ x: -2, y: -1 })).not.toEqual(undefined);
+			});
+
+			it('throws InvalidMoveError for invalid moves', () => {
+				const game = new Game({});
+				// not this player's turn
+				expect(() => game.moveToken({ from: { x: -2, y: -2 }, to: { x: -2, y: -1 } }))
+					.toThrow(InvalidMoveError);
+				// no token to move
+				expect(() => game.moveToken({ from: { x: 0, y: 0 }, to: { x: -4, y: -4 } }))
+					.toThrow(InvalidMoveError);
+			});
+
+			it('throws IllegalMoveError for illegal moves of a valid token', () => {
+				const game = new Game({});
+				expect(() => game.moveToken({ from: { x: -2, y: 0 }, to: { x: -4, y: -4 } }))
+					.toThrow(IllegalMoveError); // not a valid target for this token
+			});
+
+			it('doesn\'t allow to move a token twice in a row', () => {
+				const game = new Game({});
+				game.moveToken({ from: { x: -2, y: 0 }, to: { x: -2, y: -1 } });
+				expect(() => game.moveToken({ from: { x: -2, y: -1 }, to: { x: -2, y: 0 } }))
+					.toThrow(InvalidMoveError);
+			});
+
+			it('doesn\'t allow moving two tokens without moving a disc first', () => {
+				const game = new Game({});
+				game.moveToken({ from: { x: -2, y: 0 }, to: { x: -2, y: -1 } });
+				expect(() => game.moveToken({ from: { x: -2, y: -2 }, to: { x: -1, y: -2 } }))
+					.toThrow(InvalidMoveError);
+			});
+
+			it('updates the game state after a successful move', () => {
+				const game = new Game({});
+				expect(game.state.phase).toEqual(GamePhases.INITIAL);
+				game.moveToken({ from: { x: 2, y: 2 }, to: { x: -1, y: -1 } });
+				expect(game.state.phase).toEqual(GamePhases.MID_MOVE);
+			});
+		});
+
+		describe('#moveDisc', () => {
+			it('doesn\'t allow moving discs if a token needs to be moved first', () => {
+				const game = new Game({});
+				expect(game.state.phase).toEqual(GamePhases.INITIAL);
+				expect(() => game.moveDisc({ from: { x: -2, y: -1 }, to: { x: 2, y: 3 } }))
+					.toThrow(InvalidMoveError);
+			});
+
+			it('only works in MID_MOVE phase', () => {
+				const game = new Game({});
+				expect(game.state.phase).toEqual(GamePhases.INITIAL);
+				game.state.phase = GamePhases.MID_MOVE;
+				expect(() => game.moveDisc({ from: { x: -2, y: -1 }, to: { x: 2, y: 3 } }))
+					.not.toThrow();
+				expect(game.state.board.getDisc({ x: 2, y: 3 })).not.toEqual(undefined);
+			});
+
+			it('doesn\'t allow moving discs to invalid locations', () => {
+				const game = new Game({ gamestate: { phase: GamePhases.MID_MOVE } });
+				expect(() => game.moveDisc({ from: { x: -2, y: -1 }, to: { x: 2, y: 4 } }))
+					.toThrow(IllegalMoveError);
+			});
+
+			it('doesn\'t allow moving unmoveable discs', () => {
+				const game = new Game({ gamestate: { phase: GamePhases.MID_MOVE } });
+				expect(() => game.moveDisc({ from: { x: -2, y: -2 }, to: { x: 2, y: 3 } }))
+					.toThrow(IllegalMoveError);
+			});
+
+			it('doesn\'t allow moving discs to locations only attached to one other disc', () => {
+				const game = new Game({ gamestate: { phase: GamePhases.MID_MOVE } });
+				expect(() => game.moveDisc({ from: { x: -2, y: -1 }, to: { x: 3, y: 3 } }))
+					.toThrow(IllegalMoveError);
+			});
+		});
+
+		describe('movement', () => {
+			it('should manage the game state according to actions', () => {
+				const game = new Game({});
+				expect(game.state.phase).toEqual(GamePhases.INITIAL);
+				expect(game.state.turn).toEqual(0);
+				game.moveToken({ from: { x: 2, y: 2 }, to: { x: -1, y: -1 } });
+				expect(game.state.phase).toEqual(GamePhases.MID_MOVE);
+				game.moveDisc({ from: { x: -2, y: -1 }, to: { x: 2, y: 3 } });
+				expect(game.state.phase).toEqual(GamePhases.INITIAL);
+				expect(game.state.turn).toEqual(1);
+			});
+
+			it('should not allow managing the opponent\'s game pieces', () => {
+				// in move 0, it's player0's turn, but (-2,-2) is player1's token
+				const game = new Game({ gamestate: { turn: 0 } });
+				expect(() => game.moveToken({ from: { x: -2, y: -2 }, to: { x: -1, y: -1 } }))
+					.toThrow(InvalidMoveError);
+
+				// in move 1, it should be player1's turn
+				game.state.turn = 1;
+				// (2,2) is player0's token
+				expect(() => game.moveToken({ from: { x: 2, y: 2 }, to: { x: -1, y: -1 } }))
+					.toThrow(InvalidMoveError);
+				// (-2,-2) is player1's token:
+				expect(() => game.moveToken({ from: { x: -2, y: -2 }, to: { x: 1, y: 1 } }))
+					.not.toThrow();
+			});
+
+			it('allows for many turns', () => {
+				const game = new Game({ gamestate: { turn: 854623873 } });
+				expect(() => game.moveToken({ from: { x: -2, y: -2 }, to: { x: 1, y: 1 } }))
+					.not.toThrow();
+
+				expect(game.state.board.getToken({ x: -2, y: -2 })).toEqual(undefined);
+				expect(game.state.board.getToken({ x: 1, y: 1 })).not.toEqual(undefined);
 			});
 		});
 	});

--- a/lib/Game.test.js
+++ b/lib/Game.test.js
@@ -1,0 +1,31 @@
+const gameModule = require('./Game');
+const { GamesModelMock } = require('./models/Games.mock');
+
+describe('Game', () => {
+	describe('dependency injection', () => {
+		it('exports a function taking an optional model as argument', () => {
+			expect(gameModule instanceof Function).toBe(true);
+
+			expect(gameModule().Game instanceof Function).toBe(true);
+			const defaultGame = new (gameModule().Game)({});
+			expect(defaultGame).not.toBe(undefined);
+
+			const modifiedGame = new (gameModule(() => {}).Game)({});
+			expect(modifiedGame).not.toBe(undefined);
+		});
+	});
+
+	describe('use cases', () => {
+		describe('#createNew', () => {
+			it('creates a new game and returns it after persisting to the model', () => {
+				const mock = new GamesModelMock();
+				const { Game } = gameModule(mock);
+				expect(mock.count()).toEqual(0);
+
+				const game = Game.createNew({});
+				expect(mock.count()).toEqual(1);
+				expect(game).toBeInstanceOf(Game);
+			});
+		});
+	});
+});

--- a/lib/models/Games.mock.js
+++ b/lib/models/Games.mock.js
@@ -1,0 +1,27 @@
+class GamesModelMock {
+	constructor() {
+		this.data = {};
+	}
+
+	get(id) {
+		return this.data[id];
+	}
+
+	set(id, data) {
+		this.data[id] = data;
+		return this;
+	}
+
+	all() {
+		return Object.values(this.data);
+	}
+
+	// utitlity functions
+	count() {
+		return Object.values(this.data).length;
+	}
+}
+
+module.exports = {
+	GamesModelMock,
+};

--- a/lib/models/Games.model.js
+++ b/lib/models/Games.model.js
@@ -1,0 +1,24 @@
+const db = require('quick.db');
+
+class GameModel {
+	constructor() {
+		// eslint-disable-next-line new-cap
+		this.table = new db.table('games');
+	}
+
+	get(id) {
+		return this.table.get(id);
+	}
+
+	set(id, data) {
+		return this.table.set(id, data);
+	}
+
+	all() {
+		return this.table.all().map((item) => JSON.parse(item.data));
+	}
+}
+
+module.exports = {
+	GameModel,
+};

--- a/routes/api/game.js
+++ b/routes/api/game.js
@@ -1,4 +1,4 @@
-const { Game } = require('../../lib/Game');
+const { Game } = require('../../lib/Game')();
 
 module.exports = (router) => {
 	router.get('/games', (req, res, next) => {

--- a/routes/api/index.js
+++ b/routes/api/index.js
@@ -2,7 +2,7 @@ const express = require('express');
 
 const { ApplicationError } = require('../../lib/Errors');
 
-const { Game } = require('../../lib/Game');
+const { Game } = require('../../lib/Game')();
 
 const initGameRoutes = require('./game');
 const initMoveRoutes = require('./move');

--- a/routes/api/move.js
+++ b/routes/api/move.js
@@ -1,4 +1,4 @@
-const { Game } = require('../../lib/Game');
+const { Game } = require('../../lib/Game')();
 
 module.exports = (router) => {
 	router.post('/moveToken', (req, res, next) => {


### PR DESCRIPTION
YES-15
- discs can now only be moved to positions where they touch at least two other discs
- updates the board tests accordingly
- adds optional dependency injection to Game use case, to enable mocking the database for tests
- adds a bunch of tests for the Game use case
- adds a 404 error if searching for a game by pid and it does not exist